### PR TITLE
Update CouchDB version.

### DIFF
--- a/MVP/setup/couch.sh
+++ b/MVP/setup/couch.sh
@@ -23,11 +23,11 @@ sudo mkdir /home/couchdb
 sudo chown couchdb:couchdb /home/couchdb
  
 # Get source - need URL for mirror (see blog instructions)
-wget http://mirror.stjschools.org/public/apache/couchdb/source/2.1.1/apache-couchdb-2.1.1.tar.gz
+wget http://mirror.stjschools.org/public/apache/couchdb/source/2.1.2/apache-couchdb-2.1.2.tar.gz
  
 # extract source and enter source directory
-tar zxvf apache-couchdb-2.1.1.tar.gz 
-cd apache-couchdb-2.1.1/
+tar zxvf apache-couchdb-2.1.2.tar.gz 
+cd apache-couchdb-2.1.2/
  
 # configure build and make executable(s)
 ./configure

--- a/MVP/setup/couchBld.sh
+++ b/MVP/setup/couchBld.sh
@@ -23,11 +23,11 @@ sudo mkdir /home/couchdb
 sudo chown couchdb:couchdb /home/couchdb
  
 # Get source - need URL for mirror (see blog instructions)
-wget http://mirror.stjschools.org/public/apache/couchdb/source/2.1.1/apache-couchdb-2.1.1.tar.gz
+wget http://mirror.stjschools.org/public/apache/couchdb/source/2.1.2/apache-couchdb-2.1.2.tar.gz
  
 # extract source and enter source directory
-tar zxvf apache-couchdb-2.1.1.tar.gz 
-cd apache-couchdb-2.1.1/
+tar zxvf apache-couchdb-2.1.2.tar.gz 
+cd apache-couchdb-2.1.2/
  
 # configure build and make executable(s)
 ./configure
@@ -41,4 +41,4 @@ cd /home/couchdb/etc
 
 # Clean up
 #sudo rm /home/pi/erlang_solutions.asc
-#sudo rm /home/pi/apache-couchdb-2.1.1.tar.gz
+#sudo rm /home/pi/apache-couchdb-2.1.2.tar.gz


### PR DESCRIPTION
http://mirror.stjschools.org/public/apache/couchdb/source/2.1.1/apache-couchdb-2.1.1.tar.gz is no longer disponible, so it produces 404 error, while 2.1.2 version seems to have taken its place.